### PR TITLE
Wechsel von 4 auf 5 Vorstandsämter für Mitgliederversammlung 2025

### DIFF
--- a/statutes/Vereinsstatuten.md
+++ b/statutes/Vereinsstatuten.md
@@ -69,7 +69,8 @@ Im Vorstand sind folgende Ressorts vertreten:
 *	Präsidium
 *	Vizepräsidium
 *	Finanzen
-*	Aktuariat und PR-Verantwortliche/r
+*	Aktuariat
+*   IT-Verantwortlicher
 
 Ämterkumulation ist möglich. Der Vorstand konstituiert sich selber. 
 Der Vorstand versammelt sich sooft es die Geschäfte verlangen. Jedes Vorstandsmitglied kann unter Angabe der Gründe die Einberufung einer Sitzung verlangen.


### PR DESCRIPTION
Durch den Wechsel der Vorstandsfunktionen zur Mitgliederversammlung 2024 war die Frist für die Anpassung der Statuten an die neuen Vorstandsämter bereits verstrichen. 
Das soll bei der Mitgliederversammlung 2025 nachgeholt werden